### PR TITLE
fix GetEssentialNutritionalNeedsInOneDay return format

### DIFF
--- a/Server.Application/Services/NutrientSuggestionService.cs
+++ b/Server.Application/Services/NutrientSuggestionService.cs
@@ -4,6 +4,8 @@ using Server.Application.DTOs.NutrientSuggestion;
 using Server.Application.Interfaces;
 using Server.Domain.Entities;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Server.Application.Services
 {
@@ -176,11 +178,16 @@ namespace Server.Application.Services
                 var salt = otherNSA.FirstOrDefault(ns => ns.Attribute.Nutrient.Name.Equals("Salt")).Attribute;
 
 
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = null, // Keep original casing
+                    DictionaryKeyPolicy = null
+                };
 
                 return new Result<object>()
                 {
                     Error = 0,
-                    Data = new
+                    Data = JsonSerializer.Serialize(new
                     {
                         Energy = energySuggestion.BaseCalories + energySuggestion.AdditionalCalories,
                         PLGSubstances = new
@@ -209,7 +216,7 @@ namespace Server.Application.Services
                         },
                         Minerals = new
                         {
-                            Canxi = new
+                            Calcium = new
                             {
                                 demand = $"{canxi.MinValuePerDay} - {canxi.MaxValuePerDay}",
                                 unit = $"{canxi.Unit}"
@@ -302,7 +309,7 @@ namespace Server.Application.Services
                             }
                         }
 
-                    }
+                    }, options)
                 };
             }
             catch (Exception ex)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the daily essential nutritional needs endpoint to return its data as a JSON string rather than a raw object, improving consistency across responses.
  * Property names now retain their original casing in the JSON output.
  * Renamed the mineral field from “Canxi” to “Calcium” for clarity and standard terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->