### PR TITLE
Forget to use middleware ratelimiter

### DIFF
--- a/Server.API/Program.cs
+++ b/Server.API/Program.cs
@@ -3,6 +3,7 @@ using Hangfire.MemoryStorage;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Server.API.Middlewares;
 using Server.Application;
 using Server.Application.Commons;
 using Server.Application.HangfireInterface;
@@ -12,6 +13,7 @@ using Server.Infrastructure.Hubs;
 using Server.WebAPI;
 using Server.WebAPI.Middlewares;
 using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -160,6 +162,8 @@ app.UseAuthorization();
 
 // Use Global Exception Middleware 
 app.UseMiddleware<GlobalExceptionMiddleware>();
+
+app.UseMiddleware<RateLimitMiddleware>();
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API now enforces request rate limits. High-frequency calls may be temporarily throttled, returning HTTP 429 responses.
  * Clients receive standard retry guidance via headers (e.g., Retry-After and rate-limit headers) to help manage request pacing.
  * Typical usage patterns should be unaffected; only sustained bursts above defined thresholds will be limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->